### PR TITLE
Add user id and screen name for authorized user

### DIFF
--- a/lib/twitter-pin-auth.js
+++ b/lib/twitter-pin-auth.js
@@ -99,12 +99,14 @@ TwitterPinAuth.prototype.authorize = function(pin, cb) {
     var that = this;
     return new P(function(resolve, reject) {
         that.oa.getOAuthAccessToken(that._data.oauthToken, that._data.oauthTokenSecret, pin,
-            function(err, oauthAccessToken, oauthAccessTokenSecret) {
+            function(err, oauthAccessToken, oauthAccessTokenSecret, extras) {
                 var error = that._identifyAuthorizationError(err);
                 if (error) {
                     reject(error);
                 } else {
                     resolve({
+                        userId: extras.user_id,
+                        screenName: extras.screen_name,
                         accessTokenKey: oauthAccessToken,
                         accessTokenSecret: oauthAccessTokenSecret
                     });


### PR DESCRIPTION
Return userId and screenName for authorized user in `authorize` method.
